### PR TITLE
Nový způsob zpracování data a času.

### DIFF
--- a/src/Inkluzitron/Services/TypeReaders/DateTimeTypeReader.cs
+++ b/src/Inkluzitron/Services/TypeReaders/DateTimeTypeReader.cs
@@ -20,6 +20,8 @@ namespace Inkluzitron.Services.TypeReaders
             { new Regex("^(te[dď]|now|teraz)$", regexOptions), () => DateTime.Now } // teď, ted, now, teraz
         };
 
+        private Regex TimeShiftRegex { get; } = new(@"^(\d+)(m|h|d|M|y)$", regexOptions);
+
         public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
             // US dates use '/' as delimeter. We use this fact to detect american dates and parse them correctly (MM/DD instead of DD.MM)
@@ -34,6 +36,35 @@ namespace Inkluzitron.Services.TypeReaders
                 if (func.Key.IsMatch(input))
                     return Task.FromResult(TypeReaderResult.FromSuccess(func.Value()));
             }
+
+            var timeShift = TimeShiftRegex.Match(input);
+            if (timeShift.Success)
+            {
+                var result = DateTime.Now;
+                var timeValue = Convert.ToInt32(timeShift.Groups[1].Value);
+
+                switch (timeShift.Groups[2].Value)
+                {
+                    case "m": // minutes
+                        result = result.AddMinutes(timeValue);
+                        break;
+                    case "h": // hours
+                        result = result.AddHours(timeValue);
+                        break;
+                    case "d": // days
+                        result = result.AddDays(timeValue);
+                        break;
+                    case "M":
+                        result = result.AddMonths(timeValue);
+                        break;
+                    case "y":
+                        result = result.AddYears(timeValue);
+                        break;
+                }
+
+                return Task.FromResult(TypeReaderResult.FromSuccess(result));
+            }
+
 
             return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Datum a čas není ve správném formátu."));
         }

--- a/src/Inkluzitron/Services/TypeReaders/DateTimeTypeReader.cs
+++ b/src/Inkluzitron/Services/TypeReaders/DateTimeTypeReader.cs
@@ -20,7 +20,7 @@ namespace Inkluzitron.Services.TypeReaders
             { new Regex("^(te[dď]|now|teraz)$", regexOptions), () => DateTime.Now } // teď, ted, now, teraz
         };
 
-        private Regex TimeShiftRegex { get; } = new(@"^(\d+)(m|h|d|M|y)$", regexOptions);
+        private Regex TimeShiftRegex { get; } = new(@"(\d+)(m|h|d|M|y|r)", regexOptions);
 
         public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
@@ -38,9 +38,10 @@ namespace Inkluzitron.Services.TypeReaders
             }
 
             var timeShift = TimeShiftRegex.Match(input);
-            if (timeShift.Success)
+            var timeShiftMatched = timeShift.Success;
+            var result = DateTime.Now;
+            while (timeShift.Success)
             {
-                var result = DateTime.Now;
                 var timeValue = Convert.ToInt32(timeShift.Groups[1].Value);
 
                 switch (timeShift.Groups[2].Value)
@@ -54,19 +55,21 @@ namespace Inkluzitron.Services.TypeReaders
                     case "d": // days
                         result = result.AddDays(timeValue);
                         break;
-                    case "M":
+                    case "M": // months
                         result = result.AddMonths(timeValue);
                         break;
-                    case "y":
+                    case "r":
+                    case "y": // years
                         result = result.AddYears(timeValue);
                         break;
                 }
 
-                return Task.FromResult(TypeReaderResult.FromSuccess(result));
+                timeShift = timeShift.NextMatch();
             }
 
-
-            return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Datum a čas není ve správném formátu."));
+            return timeShiftMatched
+                ? Task.FromResult(TypeReaderResult.FromSuccess(result))
+                : Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Datum a čas není ve správném formátu."));
         }
     }
 }


### PR DESCRIPTION
Přidán nový způsob, jak načítat datum a čas. Jedná se o formát, který se používá v GrillBot na unverify.

Prakticky se jedná o časový posun od aktuálního data a času (v lokální časové zóně) o určitou dobu. Je možné zadat minuty (`m`), hodiny (`h`), dny (`d`), měsíce (`M`) a roky (`y`). Například: `10m`, `15h`, `30d`, `2M`, `3y`. 

Pro posun o vteřiny nevidím mě nenapadl use case.

Praktický příklad: Mám `1. 7. 2021 15:30:25`. Zavolám příkaz s parametrem `30m`. Příkaz dostane na vstupu datum a čas `1. 7. 2021 16:00:25`.

Jednotky nelze za sebou spojovat ani kombinovat. Tudíž nelze (a nebylo tak ani zamýšleno, že by mělo fungovat) parametry jako třeba `1h15m`, ... Pak by bylo třeba vyřešit věci jako logické seřazení jednotek, ...